### PR TITLE
Changed networktype/CNI since okd 4.15 requires OVNKubernetes as CNI

### DIFF
--- a/okd/golden-cluster/templates/install-config.yaml.j2
+++ b/okd/golden-cluster/templates/install-config.yaml.j2
@@ -21,7 +21,7 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:


### PR DESCRIPTION
Changed networktype/CNI since okd 4.15 requires OVNKubernetes as CNI in template